### PR TITLE
Configurable minimum psyfocus for autocasts

### DIFF
--- a/1.4/Languages/English/Keyed/Settings.xml
+++ b/1.4/Languages/English/Keyed/Settings.xml
@@ -68,6 +68,8 @@
   <BetterAutocastVPE.AutocastIntervalDrafted.Description>Autocasting interval while drafted (only applies to patched psycasts)</BetterAutocastVPE.AutocastIntervalDrafted.Description>
   <BetterAutocastVPE.AutocastIntervalUndrafted>Undrafted autocasting interval: {0} ticks</BetterAutocastVPE.AutocastIntervalUndrafted>
   <BetterAutocastVPE.AutocastIntervalUndrafted.Description>Autocasting interval while undrafted (only applies to patched psycasts)</BetterAutocastVPE.AutocastIntervalUndrafted.Description>
+  <BetterAutocastVPE.MinFocusThreshold>Minimum psyfocus threshold: {0}%</BetterAutocastVPE.MinFocusThreshold>
+  <BetterAutocastVPE.MinFocusThreshold.Description>Minimum psyfocus amount when a colonist will autocast</BetterAutocastVPE.MinFocusThreshold.Description>
   <BetterAutocastVPE.MendHealthThreshold>Mend health threshold (maximum): {0}</BetterAutocastVPE.MendHealthThreshold>
   <BetterAutocastVPE.MendHealthThreshold.Description>Maximum health for an item to be auto-targeted</BetterAutocastVPE.MendHealthThreshold.Description>
   <BetterAutocastVPE.MendPawns>Mend equipped gear</BetterAutocastVPE.MendPawns>

--- a/1.5/Languages/English/Keyed/Settings.xml
+++ b/1.5/Languages/English/Keyed/Settings.xml
@@ -69,6 +69,8 @@
   <BetterAutocastVPE.AutocastIntervalDrafted.Description>Autocasting interval while drafted (only applies to patched psycasts)</BetterAutocastVPE.AutocastIntervalDrafted.Description>
   <BetterAutocastVPE.AutocastIntervalUndrafted>Undrafted autocasting interval: {0} ticks</BetterAutocastVPE.AutocastIntervalUndrafted>
   <BetterAutocastVPE.AutocastIntervalUndrafted.Description>Autocasting interval while undrafted (only applies to patched psycasts)</BetterAutocastVPE.AutocastIntervalUndrafted.Description>
+  <BetterAutocastVPE.MinFocusThreshold>Minimum psyfocus threshold: {0}%</BetterAutocastVPE.MinFocusThreshold>
+  <BetterAutocastVPE.MinFocusThreshold.Description>Minimum psyfocus amount when a colonist will autocast</BetterAutocastVPE.MinFocusThreshold.Description>
   <BetterAutocastVPE.MendHealthThreshold>Mend health threshold (maximum): {0}</BetterAutocastVPE.MendHealthThreshold>
   <BetterAutocastVPE.MendHealthThreshold.Description>Maximum health for an item to be auto-targeted</BetterAutocastVPE.MendHealthThreshold.Description>
   <BetterAutocastVPE.MendPawns>Mend equipped gear</BetterAutocastVPE.MendPawns>

--- a/Source/Helpers/PawnHelper.cs
+++ b/Source/Helpers/PawnHelper.cs
@@ -116,6 +116,7 @@ internal static class PawnHelper
         return pawn?.Downed == false
             && pawn.HasPsylink
             && pawn.Awake()
+            && pawn.psychicEntropy.CurrentPsyfocus >= BetterAutocastVPE.Settings.MinFocusThreshold
             && (
                 pawn.CurJob is null
                 || !BetterAutocastVPE.Settings.BlockedJobDefs.Contains(pawn.CurJobDef.defName)

--- a/Source/Settings/AutocastSettings.cs
+++ b/Source/Settings/AutocastSettings.cs
@@ -81,6 +81,7 @@ public class AutocastSettings : ModSettings
     public bool ShowValidationMessages;
     public int AutocastIntervalDrafted;
     public int AutocastIntervalUndrafted;
+    public float MinFocusThreshold;
     public HashSet<string> DraftedAutocastDefs;
     public HashSet<string> UndraftedAutocastDefs;
     public HashSet<string> BlockedJobDefs;
@@ -230,6 +231,7 @@ public class AutocastSettings : ModSettings
         ShowValidationMessages = false;
         AutocastIntervalDrafted = 30;
         AutocastIntervalUndrafted = 600;
+        MinFocusThreshold = 0;
         DraftedAutocastDefs = DefaultDraftedAutocastDefs();
         UndraftedAutocastDefs = DefaultUndraftedAutocastDefs();
         BlockedJobDefs = DefaultBlockedJobDefs();
@@ -366,6 +368,7 @@ public class AutocastSettings : ModSettings
         LookStruct(() => ShowValidationMessages);
         LookStruct(() => AutocastIntervalDrafted);
         LookStruct(() => AutocastIntervalUndrafted);
+        LookStruct(() => MinFocusThreshold);
 
         #region Mend
         LookStruct(() => MendHealthThreshold);

--- a/Source/Settings/AutocastSettings.cs
+++ b/Source/Settings/AutocastSettings.cs
@@ -231,7 +231,7 @@ public class AutocastSettings : ModSettings
         ShowValidationMessages = false;
         AutocastIntervalDrafted = 30;
         AutocastIntervalUndrafted = 600;
-        MinFocusThreshold = 0;
+        MinFocusThreshold = 0.5f;
         DraftedAutocastDefs = DefaultDraftedAutocastDefs();
         UndraftedAutocastDefs = DefaultUndraftedAutocastDefs();
         BlockedJobDefs = DefaultBlockedJobDefs();

--- a/Source/Settings/AutocastSettingsWindow.cs
+++ b/Source/Settings/AutocastSettingsWindow.cs
@@ -425,6 +425,17 @@ public static class AutocastSettingsWindow
                 )
             );
 
+        Settings.MinFocusThreshold = (float)
+            listing.SliderLabeled(
+                "BetterAutocastVPE.MinFocusThreshold".TranslateSafe(
+                    (int)(Settings.MinFocusThreshold * 100)
+                ),
+                Settings.MinFocusThreshold,
+                0f,
+                1f,
+                tooltip: "BetterAutocastVPE.MinFocusThreshold.Description".TranslateSafe()
+            );
+
         listing.GapLine();
         listing.Label("BetterAutocastVPE.BlockedJobs.Explanation".TranslateSafe());
         if (listing.ButtonText("BetterAutocastVPE.BlockedJobs".TranslateSafe()))


### PR DESCRIPTION
Added new slider in mod settings window for minimum psyfocus. Colonist will not autocast if his psyfocus level below this value. This is helpful when you want to keep some psyfocus level for unexpected situations.